### PR TITLE
Fixing startuml parsing to support id and filename

### DIFF
--- a/lib/plantuml-preview-view.coffee
+++ b/lib/plantuml-preview-view.coffee
@@ -210,9 +210,9 @@ class PlantumlPreviewView extends ScrollView
       currentExtension = defaultExtension
       pageCount = 1
 
-      filename = uml.match ///@start(?:uml|math|latex)([^\n]*)\n///i
+      filename = uml.match ///@start(?:uml|math|latex)(\(id[^\s]*)?([^\n]*)\n///i
       if filename?
-        filename = filename[1].trim()
+        filename = filename[2].trim()
         if filename != ''
           if path.extname(filename)
             currentExtension = path.extname filename


### PR DESCRIPTION
Fixed the regex for the  startuml command to correctly parse
both id and filename declarations.
Fix for #41 